### PR TITLE
Add ability to set the value from Player

### DIFF
--- a/src/DynamoCore/Engine/EngineController.cs
+++ b/src/DynamoCore/Engine/EngineController.cs
@@ -440,6 +440,9 @@ namespace Dynamo.Engine
             {
                 if (!node.IsInputNode) continue;
 
+                //We also don't want any nodes that do have input ports or where derived from custom nodes.
+                if (node.InPorts.Any() || node.IsCustomFunction) continue;
+
                 // Only one or the other of the two lists, Added or Modified, will match the node GUID if they do. 
                 bool isAdded = false;
                 for (int i = 0; i < graphSyncdata.AddedSubtrees.Count; i++)

--- a/src/Libraries/CoreNodeModels/DefineData.cs
+++ b/src/Libraries/CoreNodeModels/DefineData.cs
@@ -76,10 +76,7 @@ namespace CoreNodeModels
             }
         }
 
-        /// <summary>
-        ///     Indicates whether Node is input or not.
-        ///     Used to bind visibility of UI for user selection.
-        /// </summary>
+        [JsonIgnore]
         public override bool IsInputNode
         {
             get { return true; }
@@ -199,6 +196,12 @@ namespace CoreNodeModels
         /// <param name="data"></param>
         private void DataBridgeCallback(object data)
         {
+            //Todo If the playerValue is not empty string then we can chanage the UI to reflect the value is coming from the player
+            //Todo if the function call throws we don't get back to DatabridgeCallback.  Not sure if we need to handle this case
+
+            //Now we reset this value to empty string so that the next time a value is set from upstream nodes we can know that it is not coming from the player
+            playerValue = "";
+
             if (data == null) return;
 
             (bool IsValid, bool UpdateList, DataNodeDynamoType InputType) resultData = (ValueTuple<bool, bool, DataNodeDynamoType>)data;
@@ -225,12 +228,6 @@ namespace CoreNodeModels
                     SelectedIndex = 0;
                 }
             }
-
-            //Todo If the playerValue is not empty string then we can chanage the UI to reflect the value is coming from the player
-
-            //Now we reset this value to empty string so that the next time a value is set from upstream nodes we can know that it is not coming from the player
-            playerValue = "";
-
         }
 
 

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -624,7 +624,9 @@ namespace DSCore
         public static Dictionary<string, object> IsSupportedDataNodeType([ArbitraryDimensionArrayImport] object inputValue,
             string typeString, bool isList, bool isAutoMode, string playerValue)
         {
-            if(playerValue != null)
+            // If the playerValue is not empty, then we assume it was set by the player.
+            // In that case, we need to parse it to get the actual value replace the inputValue.
+            if (!string.IsNullOrEmpty(playerValue))
             {
                 try
                 {

--- a/src/Libraries/CoreNodes/Data.cs
+++ b/src/Libraries/CoreNodes/Data.cs
@@ -622,8 +622,21 @@ namespace DSCore
 
         [IsVisibleInDynamoLibrary(false)]
         public static Dictionary<string, object> IsSupportedDataNodeType([ArbitraryDimensionArrayImport] object inputValue,
-            string typeString, bool isList, bool isAutoMode)
+            string typeString, bool isList, bool isAutoMode, string playerValue)
         {
+            if(playerValue != null)
+            {
+                try
+                {
+                    inputValue = ParseJSON(playerValue);
+                }
+                catch (Exception ex)
+                {
+                    dynamoLogger?.Log("A Player value failed to deserialize with this exception: " + ex.Message);
+                    throw new NotSupportedException(Properties.Resources.Exception_Deserialize_Unsupported_Cache);
+                }
+            }
+
             if(inputValue == null) { return null; }
 
             object result;  // Tuple<IsValid: bool, UpdateList: bool, InputType: DataNodeDynamoType>


### PR DESCRIPTION
### Purpose

This code change does the following:

1) Lets the DataIO node to be set as an input node
2) Adds the option to pass data in from the DynamoPlayer vs only the upstream nodes.
3) Fix VM to make this version of inputs possible

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB

### Release Notes

(FILL ME IN) Brief description of the fix / enhancement. **Mandatory section**

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
